### PR TITLE
Fix ChannelSize mapping and add tests

### DIFF
--- a/src/color_format.rs
+++ b/src/color_format.rs
@@ -55,7 +55,7 @@ impl ChannelSize {
             8 => ChannelSize::_8bit,
             16 => ChannelSize::_16bit,
             32 => ChannelSize::_32bit,
-            62 => ChannelSize::_64bit,
+            64 => ChannelSize::_64bit,
             _ => panic!("Invalid channel size: {:?}", bit_count),
             // @formatter:on
         }

--- a/src/tests/color_format_tests.rs
+++ b/src/tests/color_format_tests.rs
@@ -1,0 +1,7 @@
+use crate::color_format::ChannelSize;
+
+#[test]
+fn from_bit_count_returns_64bit() {
+    let size = ChannelSize::from_bit_count(64);
+    assert_eq!(size, ChannelSize::_64bit);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,2 +1,4 @@
 #[cfg(test)]
 mod image_tests;
+#[cfg(test)]
+mod color_format_tests;


### PR DESCRIPTION
## Summary
- correct channel size for 64-bit data
- exercise `ChannelSize::from_bit_count` with a new test

## Testing
- `cargo test --quiet` *(fails: could not download crates)*