### PR TITLE
Fix RGBAI TIFF support

### DIFF
--- a/src/tests/image_tests.rs
+++ b/src/tests/image_tests.rs
@@ -124,3 +124,32 @@ fn image_convertion() {
         .save_file("./test_output/convertion-x2-rgba-u16.tiff")
         .unwrap();
 }
+
+#[test]
+fn save_rgba_int_tiffs() {
+    let png = Image::read_file("./test_resources/rgba-sample-8bit.png").unwrap();
+
+    png.clone()
+        .convert(ColorFormat::RGBA_I8)
+        .unwrap()
+        .save_file("./test_output/save-rgba-i8.tiff")
+        .unwrap();
+
+    png.clone()
+        .convert(ColorFormat::RGBA_I16)
+        .unwrap()
+        .save_file("./test_output/save-rgba-i16.tiff")
+        .unwrap();
+
+    png.clone()
+        .convert(ColorFormat::RGBA_I32)
+        .unwrap()
+        .save_file("./test_output/save-rgba-i32.tiff")
+        .unwrap();
+
+    png
+        .convert(ColorFormat::RGBA_I64)
+        .unwrap()
+        .save_file("./test_output/save-rgba-i64.tiff")
+        .unwrap();
+}

--- a/src/tiff_extentions.rs
+++ b/src/tiff_extentions.rs
@@ -141,7 +141,7 @@ pub struct RGBAI8;
 impl ColorType for RGBAI8 {
     type Inner = i8;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[8, 8, 8];
+    const BITS_PER_SAMPLE: &'static [u16] = &[8, 8, 8, 8];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::Int; 4];
 }
 
@@ -150,7 +150,7 @@ pub struct RGBAI16;
 impl ColorType for RGBAI16 {
     type Inner = i16;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[16, 16, 16];
+    const BITS_PER_SAMPLE: &'static [u16] = &[16, 16, 16, 16];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::Int; 4];
 }
 
@@ -159,7 +159,7 @@ pub struct RGBAI32;
 impl ColorType for RGBAI32 {
     type Inner = i32;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[32, 32, 32];
+    const BITS_PER_SAMPLE: &'static [u16] = &[32, 32, 32, 32];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::Int; 4];
 }
 
@@ -168,7 +168,7 @@ pub struct RGBAI64;
 impl ColorType for RGBAI64 {
     type Inner = i64;
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[64, 64, 64];
+    const BITS_PER_SAMPLE: &'static [u16] = &[64, 64, 64, 64];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::Int; 4];
 }
 


### PR DESCRIPTION
## Summary
- correct `BITS_PER_SAMPLE` for RGBAI TIFF color types
- test saving TIFFs in all RGBAI formats

## Testing
- `cargo test --quiet` *(fails: Could not connect to crates.io)*
- `cargo test --offline --quiet` *(fails: no matching package named `anyhow` found)*