### PR TITLE
Fix error propagation

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -69,7 +69,7 @@ impl Image {
     }
 
     fn load_png_jpeg<P: AsRef<Path>>(filename: P) -> anyhow::Result<Image> {
-        let img = image_lib::open(filename).expect("Failed to open image");
+        let img = image_lib::open(filename)?;
 
         let (channel_count, channel_size, channel_type) = match img.color() {
             // @formatter:off

--- a/src/tests/image_tests.rs
+++ b/src/tests/image_tests.rs
@@ -1,5 +1,5 @@
 use crate::color_format::*;
-use crate::image::Image;
+use crate::image::{Image, ImageDesc};
 
 #[test]
 fn it_works() {
@@ -123,4 +123,20 @@ fn image_convertion() {
         .unwrap()
         .save_file("./test_output/convertion-x2-rgba-u16.tiff")
         .unwrap();
+}
+
+#[test]
+fn read_missing_png_propagates_error() {
+    let result = Image::read_file("./test_resources/does_not_exist.png");
+    assert!(result.is_err());
+}
+
+#[test]
+fn save_tiff_invalid_bytes_propagates_error() {
+    let desc = ImageDesc::new(1, 1, ColorFormat::GRAY_U16);
+    // 3 bytes is not a multiple of u16 size, so cast_slice should fail
+    let img = Image::new_with_data(desc, vec![0u8; 3]).unwrap();
+
+    let result = img.save_file("./test_output/invalid.tiff");
+    assert!(result.is_err());
 }

--- a/src/tiff_extentions.rs
+++ b/src/tiff_extentions.rs
@@ -330,13 +330,13 @@ fn save_tiff_internal<ColorType, P: AsRef<Path>>(image: &Image, filename: P) -> 
         ColorType: colortype::ColorType,
         [ColorType::Inner]: TiffValue,
 {
-    let buf: &[ColorType::Inner] = cast_slice(&image.bytes).unwrap();
+    let buf: &[ColorType::Inner] = cast_slice(&image.bytes)?;
 
     let mut file = File::create(filename)?;
     let mut tiff = TiffEncoder::new(&mut file)?;
     let img = tiff.new_image::<ColorType>(image.desc.width(), image.desc.height())?;
 
-    img.write_data(buf).unwrap();
+    img.write_data(buf)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- propagate errors from image loading rather than panicking
- return errors from `save_tiff_internal`
- add regression tests covering these error paths

## Testing
- `cargo test --no-run` *(fails: failed to get `anyhow`)*