### PR TITLE
Propagate tiff save errors

### DIFF
--- a/src/tests/image_tests.rs
+++ b/src/tests/image_tests.rs
@@ -124,3 +124,14 @@ fn image_convertion() {
         .save_file("./test_output/convertion-x2-rgba-u16.tiff")
         .unwrap();
 }
+
+#[test]
+fn save_tiff_with_misaligned_bytes_returns_error() {
+    use crate::image::ImageDesc;
+
+    let desc = ImageDesc::new(1, 1, ColorFormat::GRAY_U16);
+    let img = Image::new_with_data(desc, vec![0u8; 3]).unwrap();
+
+    let result = img.save_file("./test_output/misaligned.tiff");
+    assert!(result.is_err());
+}

--- a/src/tiff_extentions.rs
+++ b/src/tiff_extentions.rs
@@ -330,13 +330,13 @@ fn save_tiff_internal<ColorType, P: AsRef<Path>>(image: &Image, filename: P) -> 
         ColorType: colortype::ColorType,
         [ColorType::Inner]: TiffValue,
 {
-    let buf: &[ColorType::Inner] = cast_slice(&image.bytes).unwrap();
+    let buf: &[ColorType::Inner] = cast_slice(&image.bytes)?;
 
     let mut file = File::create(filename)?;
     let mut tiff = TiffEncoder::new(&mut file)?;
     let img = tiff.new_image::<ColorType>(image.desc.width(), image.desc.height())?;
 
-    img.write_data(buf).unwrap();
+    img.write_data(buf)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- propagate `PodCastError` and `tiff` errors when saving TIFF files
- test that misaligned byte length results in an error

## Testing
- `cargo test --quiet --offline` *(fails: no matching package named `anyhow` found)*