### PR TITLE
Fix range shifting conversions

### DIFF
--- a/src/image_convertion.rs
+++ b/src/image_convertion.rs
@@ -697,7 +697,7 @@ pub(crate) fn u64_to_u64(value: u64) -> u64 {
 
 #[inline]
 pub(crate) fn u8_to_i8(value: u8) -> i8 {
-    (value / 2) as i8
+    (value as i16 - 128) as i8
 }
 #[inline]
 pub(crate) fn u8_to_i16(value: u8) -> i16 {
@@ -718,7 +718,7 @@ pub(crate) fn u16_to_i8(value: u16) -> i8 {
 }
 #[inline]
 pub(crate) fn u16_to_i16(value: u16) -> i16 {
-    (value / 2) as i16
+    (value as i32 - 32768) as i16
 }
 #[inline]
 pub(crate) fn u16_to_i32(value: u16) -> i32 {
@@ -739,7 +739,7 @@ pub(crate) fn u32_to_i16(value: u32) -> i16 {
 }
 #[inline]
 pub(crate) fn u32_to_i32(value: u32) -> i32 {
-    (value / 2) as i32
+    (value as i64 - 2_147_483_648) as i32
 }
 #[inline]
 pub(crate) fn u32_to_i64(value: u32) -> i64 {
@@ -760,12 +760,12 @@ pub(crate) fn u64_to_i32(value: u64) -> i32 {
 }
 #[inline]
 pub(crate) fn u64_to_i64(value: u64) -> i64 {
-    (value / 2) as i64
+    (value as i128 - 9_223_372_036_854_775_808_i128) as i64
 }
 
 #[inline]
 pub(crate) fn i8_to_u8(value: i8) -> u8 {
-    value.max(0) as u8 * 2
+    (value as i16 + 128) as u8
 }
 #[inline]
 pub(crate) fn i8_to_u16(value: i8) -> u16 {
@@ -786,7 +786,7 @@ pub(crate) fn i16_to_u8(value: i16) -> u8 {
 }
 #[inline]
 pub(crate) fn i16_to_u16(value: i16) -> u16 {
-    value.max(0) as u16 * 2
+    (value as i32 + 32768) as u16
 }
 #[inline]
 pub(crate) fn i16_to_u32(value: i16) -> u32 {
@@ -807,7 +807,7 @@ pub(crate) fn i32_to_u16(value: i32) -> u16 {
 }
 #[inline]
 pub(crate) fn i32_to_u32(value: i32) -> u32 {
-    value.max(0) as u32 * 2
+    (value as i64 + 2_147_483_648) as u32
 }
 #[inline]
 pub(crate) fn i32_to_u64(value: i32) -> u64 {
@@ -828,7 +828,7 @@ pub(crate) fn i64_to_u32(value: i64) -> u32 {
 }
 #[inline]
 pub(crate) fn i64_to_u64(value: i64) -> u64 {
-    value.max(0) as u64 * 2
+    (value as i128 + 9_223_372_036_854_775_808_i128) as u64
 }
 
 #[inline]

--- a/src/tests/conversion_tests.rs
+++ b/src/tests/conversion_tests.rs
@@ -1,0 +1,54 @@
+use crate::image_convertion::{
+    u8_to_i8, i8_to_u8,
+    u16_to_i16, i16_to_u16,
+    u32_to_i32, i32_to_u32,
+    u64_to_i64, i64_to_u64,
+};
+
+#[test]
+fn round_trip_u8_i8() {
+    let vals_u = [0u8, 128, 255];
+    for &v in &vals_u {
+        assert_eq!(v, i8_to_u8(u8_to_i8(v)));
+    }
+    let vals_i = [i8::MIN, 0, i8::MAX];
+    for &v in &vals_i {
+        assert_eq!(v, u8_to_i8(i8_to_u8(v)));
+    }
+}
+
+#[test]
+fn round_trip_u16_i16() {
+    let vals_u = [0u16, 32768, 65535];
+    for &v in &vals_u {
+        assert_eq!(v, i16_to_u16(u16_to_i16(v)));
+    }
+    let vals_i = [i16::MIN, 0, i16::MAX];
+    for &v in &vals_i {
+        assert_eq!(v, u16_to_i16(i16_to_u16(v)));
+    }
+}
+
+#[test]
+fn round_trip_u32_i32() {
+    let vals_u = [0u32, 2_147_483_648u32, u32::MAX];
+    for &v in &vals_u {
+        assert_eq!(v, i32_to_u32(u32_to_i32(v)));
+    }
+    let vals_i = [i32::MIN, 0, i32::MAX];
+    for &v in &vals_i {
+        assert_eq!(v, u32_to_i32(i32_to_u32(v)));
+    }
+}
+
+#[test]
+fn round_trip_u64_i64() {
+    let vals_u = [0u64, 9_223_372_036_854_775_808u64, u64::MAX];
+    for &v in &vals_u {
+        assert_eq!(v, i64_to_u64(u64_to_i64(v)));
+    }
+    let vals_i = [i64::MIN, 0, i64::MAX];
+    for &v in &vals_i {
+        assert_eq!(v, u64_to_i64(i64_to_u64(v)));
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,2 +1,3 @@
 #[cfg(test)]
 mod image_tests;
+mod conversion_tests;


### PR DESCRIPTION
## Summary
- map unsigned values to signed ranges using subtraction
- shift signed values to unsigned equivalents using addition
- add tests for round-trip conversions

## Testing
- `cargo test --quiet` *(fails: failed to download index)*