### PR TITLE
Fix README example and add license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "imaginarium"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 
 [dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Imaginarium Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,32 +1,36 @@
-Rust library for image decoding and encoding. Supports JPEG, PNG, and TIFF.
+# Imaginarium
 
-Usage example:
-```rust
-let img = Image::read_file("image.png").unwrap();
-png
-    .convert(ColorFormat::GRAY_U16)
-    .unwrap()
-    .save_file("gray.png")
-.unwrap();
+Imaginarium is a Rust library for decoding and encoding images. It supports JPEG, PNG and TIFF formats and provides convenient utilities for converting between many color formats.
+
+## Installation
+
+Add the crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+imaginarium = "0.1"
 ```
 
-Supports wide variety of color formats and pixel types and can convert between them.
+## Usage
+
 ```rust
-pub enum ChannelCount {
-    Gray = 1,
-    GrayAlpha = 2,
-    Rgb = 3,
-    Rgba = 4,
-}
-pub enum ChannelSize {
-    _8bit = 1,
-    _16bit = 2,
-    _32bit = 4,
-    _64bit = 8,
-}
-pub enum ChannelType {
-    UInt,
-    Float,
-    Int,
+use imaginarium::{Image, ColorFormat};
+
+fn main() -> anyhow::Result<()> {
+    let img = Image::read_file("image.png")?;
+    img.convert(ColorFormat::GRAY_U16)?
+        .save_file("gray.png")?;
+    Ok(())
 }
 ```
+
+## Features
+
+- JPEG, PNG and TIFF decoding and encoding
+- Conversion between a variety of color formats
+- Generic image descriptors and pixel types
+
+## License
+
+Imaginarium is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-imaginarium = "0.1"
+imaginarium = { git = "https://github.com/xorza/imaginarium.git" }
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- expand README with install instructions, usage, and features
- mention MIT license and add LICENSE file
- declare `license = "MIT"` in Cargo.toml

## Testing
- `cargo test` *(fails: failed to download from crates.io)*